### PR TITLE
Let pass express app instead of creating a new instance within.

### DIFF
--- a/src/middleware/express.app.config.ts
+++ b/src/middleware/express.app.config.ts
@@ -22,7 +22,8 @@ export class ExpressAppConfig {
         this.definitionPath = definitionPath;
         this.routingOptions = appOptions.routing;
         this.setOpenApiValidatorOptions(definitionPath, appOptions);
-        this.app = express();
+				// Create new express app only if not passed by options
+        this.app = appOptions.app || express();
 
         const spec = fs.readFileSync(definitionPath, 'utf8');
         const swaggerDoc = jsyaml.safeLoad(spec);

--- a/src/middleware/oas3.options.ts
+++ b/src/middleware/oas3.options.ts
@@ -1,19 +1,22 @@
 import { OpenApiValidatorOpts } from 'express-openapi-validator/dist/framework/types';
 import { LoggingOptions } from './logging.options'
 import { SwaggerUiOptions } from './swagger.ui.options';
+import * as express from 'express';
 
 export class Oas3AppOptions {
     public routing: any;
     public openApiValidator: OpenApiValidatorOpts;
     public logging: LoggingOptions;
     public swaggerUI: SwaggerUiOptions;
+    public app: express.Application;
 
-    constructor(routingOpts: any, openApiValidatorOpts: OpenApiValidatorOpts, logging: LoggingOptions, swaggerUI: SwaggerUiOptions) {
+    constructor(routingOpts: any, openApiValidatorOpts: OpenApiValidatorOpts, logging: LoggingOptions, swaggerUI: SwaggerUiOptions, app: express.Application) {
         this.routing = routingOpts;
         this.openApiValidator = openApiValidatorOpts;
         this.swaggerUI = swaggerUI;
         if (!logging)
             logging = new LoggingOptions(null, null);
         this.logging = logging;
+        this.app = app;
     }
 }


### PR DESCRIPTION
This allows to handle cors / generate middlewares and so on *before* the Swagger routing.